### PR TITLE
Add existing overrides from current theme.

### DIFF
--- a/templates/islandora-basic-collection-grid.tpl.php
+++ b/templates/islandora-basic-collection-grid.tpl.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * islandora-basic-collection.tpl.php
+ *
+ * @TODO: needs documentation about file and variables
+ */
+?>
+
+<div class="islandora islandora-basic-collection">
+  <div class="islandora-basic-collection-grid clearfix">
+  <?php foreach($associated_objects_array as $key => $value): ?>
+    <dl class="islandora-basic-collection-object <?php print $value['class']; ?>">
+        <dt class="islandora-basic-collection-thumb"><?php print $value['thumb_link']; ?></dt>
+        <dd class="islandora-basic-collection-caption"><?php print filter_xss($value['title_link']); ?></dd>
+    </dl>
+  <?php endforeach; ?>
+</div>
+</div>

--- a/templates/islandora-basic-collection-wrapper.tpl.php
+++ b/templates/islandora-basic-collection-wrapper.tpl.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * islandora-basic-collection-wrapper.tpl.php
+ *
+ * @TODO: needs documentation about file and variables
+ */
+?>
+
+<div class="islandora-basic-collection-wrapper">
+  <?php if (!$display_metadata && !empty($dc_array['dc:description']['value'])): ?>
+    <p><?php print nl2br($dc_array['dc:description']['value']); ?></p>
+    <hr />
+  <?php endif; ?>
+  <div class="islandora-basic-collection clearfix">
+    <span class="islandora-basic-collection-display-switch">
+      <ul class="links inline">
+        <?php foreach ($view_links as $link): ?>
+          <li>
+            <a <?php print drupal_attributes($link['attributes']) ?>><?php print filter_xss($link['title']) ?></a>
+          </li>
+        <?php endforeach ?>
+      </ul>
+    </span>
+    <?php print $collection_pager; ?>
+    <?php print $collection_content; ?>
+    <?php print $collection_pager; ?>
+  </div>
+  <?php if ($display_metadata): ?>
+    <div class="islandora-collection-metadata">
+      <?php print $description; ?>
+      <?php if ($parent_collections): ?>
+        <div>
+          <h2><?php print t('In collections'); ?></h2>
+          <ul>
+            <?php foreach ($parent_collections as $collection): ?>
+              <li><?php print l($collection->label, "islandora/object/{$collection->id}"); ?></li>
+            <?php endforeach; ?>
+          </ul>
+        </div>
+      <?php endif; ?>
+      <?php print $metadata; ?>
+    </div>
+  <?php endif; ?>
+</div>

--- a/templates/islandora-basic-collection.tpl.php
+++ b/templates/islandora-basic-collection.tpl.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * islandora-basic-collection.tpl.php
+ *
+ * @TODO: needs documentation about file and variables
+ */
+?>
+
+<div class="islandora islandora-basic-collection">
+    <?php $row_field = 0; ?>
+    <?php foreach($associated_objects_array as $associated_object): ?>
+      <div class="islandora-basic-collection-object islandora-basic-collection-list-item clearfix">
+        <dl class="<?php print $associated_object['class']; ?>">
+            <dt>
+              <?php if (isset($associated_object['thumb_link'])): ?>
+                <?php print $associated_object['thumb_link']; ?>
+              <?php endif; ?>
+            </dt>
+            <dd class="collection-value <?php print isset($associated_object['dc_array']['dc:title']['class']) ? $associated_object['dc_array']['dc:title']['class'] : ''; ?> <?php print $row_field == 0 ? ' first' : ''; ?>">
+              <?php if (isset($associated_object['thumb_link'])): ?>
+                <strong><?php print filter_xss($associated_object['title_link']); ?></strong>
+              <?php endif; ?>
+            </dd>
+            <?php if (isset($associated_object['dc_array']['dc:date']['value'])): ?>
+                <dd class="collection-value <?php print $associated_object['dc_array']['dc:date']['class']; ?>">
+                    <?php
+                    $date = explode(",", $associated_object['dc_array']['dc:date']['value']);
+                    print filter_xss($date[0]); ?>
+                </dd>
+            <?php endif; ?>
+            <?php if (isset($associated_object['dc_array']['dc:description']['value'])): ?>
+              <dd class="collection-value <?php print $associated_object['dc_array']['dc:description']['class']; ?>">
+                <?php print filter_xss($associated_object['dc_array']['dc:description']['value']); ?>
+              </dd>
+            <?php endif; ?>
+        </dl>
+      </div>
+    <?php $row_field++; ?>
+    <?php endforeach; ?>
+</div>

--- a/templates/islandora-solr-metadata-display.tpl.php
+++ b/templates/islandora-solr-metadata-display.tpl.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @file
+ * Islandora_solr_metadata display template.
+ *
+ * Variables available:
+ * - $solr_fields: Array of results returned from Solr for the current object
+ *   based upon defined display configuration(s). The array structure is:
+ *   - display_label: The defined display label corresponding to the Solr field
+ *     as defined in the configuration in translatable string form.
+ *   - value: An array containing all the result(s) found for the specific field
+ *     in Solr for the current object when queried against Solr.
+ * - $found: Boolean indicating if a Solr doc was found for the current object.
+ * - $not_found_message: A string to print if there was no document found in
+ *   Solr.
+ *
+ * @see template_preprocess_islandora_solr_metadata_display()
+ * @see template_process_islandora_solr_metadata_display()
+ */
+?>
+<?php if ($found):
+  if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
+<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+  <legend><span class="fieldset-legend"><?php print t('Click for Details'); ?></span></legend>
+  <div class="fieldset-wrapper">
+    <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields">
+      <?php $row_field = 0; ?>
+      <?php foreach($solr_fields as $value): ?>
+        <dt class="<?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print $value['display_label']; ?>
+        </dt>
+        <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
+        </dd>
+        <?php $row_field++; ?>
+      <?php endforeach; ?>
+    </dl>
+  </div>
+</fieldset>
+  <h4>
+    <?php print l(t('View the MODS record'), "islandora/object/{$solr_fields['PID']['value'][0]}/datastream/MODS/view"); ?>
+  </h4>
+<?php endif; ?>
+<?php else: ?>
+  <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+    <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
+    <?php //XXX: Hack in markup for message. ?>
+    <div class="messages--warning messages warning">
+      <?php print $not_found_message; ?>
+    </div>
+  </fieldset>
+<?php endif; ?>


### PR DESCRIPTION
**JIRA Ticket**: [TRACE-57: Copy over existing module tpl overrides.](https://jira.lib.utk.edu/projects/TRAC/issues/TRAC-53)

# What does this Pull Request do?

This pull request copies over existing tpl overrides:

* We include a link to the MODS record in Solr Metadata Display.
* We include dates in the collection view.

# What's new?

Template overrides from digital have been copied over.

# How should this be tested?

If you have the theme enabled in an Islandora instance:

- If you're using Solr Metadata Display, a link to the MODS record is displayed.
- If you're browsing, the date is displayed with the title and thumbnail.

# Additional Notes:

No idea what those others are doing.  They were there so I grabbed them.  Probably should have diffed with Head.

# Interested parties
@dgreene-utk 
