### PR TITLE
Correction to branch of origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+\.remote-sync\.json

--- a/css/style.css
+++ b/css/style.css
@@ -416,3 +416,8 @@ dd.collection-value.dc-description {
 .islandora-solr-breadcrumb-super a {
   color: red;
 }
+.citation_author_container {
+  text-indent: -25px; 
+  padding-left: 25px;
+}
+

--- a/template.php
+++ b/template.php
@@ -46,6 +46,44 @@ function UTKdrupal_page_headers(){
 function UTKdrupal_preprocess_html(&$vars) {
   drupal_add_css(path_to_theme() . '/ie.css', array('weight' => CSS_THEME, 'browsers' => array('IE' => 'lt IE 7', '!IE' => FALSE), 'preprocess' => FALSE));
 }
+/**
+ * function extractStringValue($large_string,$unique_tag)
+ * Small utility to parse out a field value from the Details section of an Object Level Page.
+ * $large_string is any string you want to search.
+ *
+ * For the citation_author search, $large_value is defined as the value from:
+ * $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']
+ *
+ * Very simple php parsing is used.
+ *
+ * Assumptions:
+ *  large_string contains the unique_tag and the target_value
+ *  unique_tag occurs only once in large_string
+ *  target_value occurs only once in large_string
+ *  unique_tag occurs before target_value
+ *  unique_tag occurs before '>' character
+ *  target_value occurs between '>' and '<' characters.
+ *
+ * Example: target value is displayed in standard html as below.
+ * blah blah<html blah blah unique_tag blah blah>target_value</more html>
+ *
+ * function call example:
+ * $AUTHOR = extractStringValue($thisDetails,'utk_mods_etd_name_author_ms');
+ *
+ */
+
+function extractStringValue($large_string,$unique_tag){
+
+      $posit01   = strpos($large_string,$unique_tag);
+      $parse3b   = substr($large_string,$posit01,400);
+      $posit02   = strpos($parse3b,'>');
+      $parse3c   = substr($parse3b,$posit02,200);
+      $posit03   = strpos($parse3c,'<');
+      $mySTRLEN  = $posit03-1;
+      $parse3d   = substr($parse3c,1,$mySTRLEN);
+      $target_value  = $parse3d;
+      return $target_value;
+}
 
 /**
  * Set Logo path and $head variable in page.tpl.php is updated from what it was originally set to in template_preprocess_page().
@@ -96,6 +134,19 @@ function UTKdrupal_preprocess_page(&$variables, $hook) {
         }
     }
 
+
+  if (strpos(current_path(), 'utk.ir.td') !== false) {
+    if ( isset($variables['page']['content']['system_main']['citation.tab']['citation']['#markup'])) {
+      unset($variables['page']['content']['system_main']['citation.tab']['citation']['#markup']);
+      }
+      $thisDetails = $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup'];
+      $Author = extractStringValue($thisDetails,'utk_mods_etd_name_author_ms');
+      $prefix  = '<div class="csl-bib-body"><div class="citation_author_container"><div class="citation_author"><h4>';
+      $content  = $Author;
+      $suffix  = '</h4></div></div></div>';
+      $new_string = $prefix.$content.$suffix;
+      $variables['page']['content']['system_main']['citation.tab']['citation']['#markup']= $new_string;
+}
 
 }
 


### PR DESCRIPTION
**JIRA Ticket**:  [https://jira.lib.utk.edu/browse/TRAC-1059](TRAC-1059)

# What does this Pull Request do?
Google Scholar Inclusion requires that the name of the Author appear alone on the first line below the title on the Item Level Page for the object.
Our default first line had the (YEAR) in parentheses followed by the Title on this line.
This pull request causes display of Author name on the first line below the title of the item level page.

In this repository, two files are changed 
1.  UTKdrupal/template.php
2.  UTKdrupal/css/style.css

#Technical details:
The HTML markup for the Details portion of the Item level page is at:

$variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']
This is a single string of HTML markup, thousands of characters.

The Author name should be on the path:
$variables['page']['content']['system_main']['citation.tab']['citation']['#markup']

I created a small function extractStringValue to facilitate extracting the desired value (authorName) from the HTML markup.  (We expect to have to do this for other google scholar citation variables.)

In the function UTKdrupal_preprocess_page,  I revised the tags around the Author name to comply with google scholar inclusion requirements.

In style.css, a new class was added for citation_author_container.

A variable named $new_string was set equal to the  bundle of &lt;tags>Author name&lt;/tags>.

The path $variables['page']['content']['system_main']['citation.tab']['citation']['#markup']
was given the value $new_string.

# How should this be tested?

This code is on UTKdrupal (TRAC-1059-H)

In vagrant, bring up TRAC (TRAC-1059).
>>  vagrant up
after it is up
>> cd $DRUPAL_HOME/sites/all/themes/UTKdrupal
>> git fetch origin
>> ls-remote
This gives a list.  You are looking for:
0d57ea34e9793f6c7b00f5e3f709f8441ee9ae61	refs/pull/11/head

>> git checkout pr-11
>> git checkout css/style.css
>> git checkout template.php
>> drush cc all

Now you are ready to test on the vagrant trace home page in the browser.
    Go to vagrant TRACE home page.
    Scroll down to the search by date across all collections link.
    On the iby page (Search by Date), click on 2008 because the default ETDS in vagrant give results for this year.
    After you get the search results for the 2008 search, click on a Title that will bring up an Item Level result page.
    On the Item Level page, you should see the Author name on the first line below the title.
     The Author name should be in a font that is smaller than Title and larger than the word "Downloads" below it.
    Click on inspect element for Author to see if it is wrapped in the following tags:
&lt;div class="csl-bib-body">
    &nbsp;&nbsp;&nbsp;&nbsp;&lt;div class="citation_author_container">
         &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&lt;div class="citation_author">
           &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; &lt;h4>Hull, Robert Alexander&lt;/h4>
       &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; &lt;/div>
   &nbsp;&nbsp;&nbsp;&nbsp;  &lt;/div>
&lt;/div>

    Please check at least 3 titles for correct display on Item Level page.


# Interested parties
@DonRichards @CanOfBees 