### PR TITLE
Revise font size of Abstract Header per TRAC-1120

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -420,4 +420,8 @@ dd.collection-value.dc-description {
   text-indent: -25px; 
   padding-left: 25px;
 }
+.citation_abstract_container {
+  text-indent: -25px; 
+  padding-left: 25px;
+}
 

--- a/template.php
+++ b/template.php
@@ -140,15 +140,18 @@ function UTKdrupal_preprocess_page(&$variables, $hook) {
       unset($variables['page']['content']['system_main']['citation.tab']['citation']['#markup']);
       }
       $thisDetails = $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup'];
+      //Revise for Author display
       $Author = extractStringValue($thisDetails,'utk_mods_etd_name_author_ms');
-      $prefix  = '<div class="csl-bib-body"><div class="citation_author_container"><div class="citation_author"><h4>';
+      $prefix  = '<div class="csl-bib-body"><div class="citation_author_container"><h>4 class="citation_author">';
       $content  = $Author;
-      $suffix  = '</h4></div></div></div>';
+      $suffix  = '</h4></div></div>';
       $new_string = $prefix.$content.$suffix;
       $variables['page']['content']['system_main']['citation.tab']['citation']['#markup']= $new_string;
-      $count = 2;
-      $new_thisDetails = str_replace("h2>","h5>",$thisDetails,$count);
-      $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']=$new_thisDetails;
+      //$Revise for Abstract label display
+      $thisDetails2 = str_replace('<h2>','<div class="citation_abstract_container"><h5>',$thisDetails);
+      $thisDetails3 = str_replace('<p property="description">','<p property="description" class="citation_abstract">',$thisDetails2);
+      $thisDetails4 = str_replace('</h2>','</h5></div>',$thisDetails3);
+      $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']=$thisDetails4;
 }
 
 }

--- a/template.php
+++ b/template.php
@@ -146,6 +146,9 @@ function UTKdrupal_preprocess_page(&$variables, $hook) {
       $suffix  = '</h4></div></div></div>';
       $new_string = $prefix.$content.$suffix;
       $variables['page']['content']['system_main']['citation.tab']['citation']['#markup']= $new_string;
+      $count = 2;
+      $new_thisDetails = str_replace("h2>","h5>",$thisDetails,$count);
+      $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']=$new_thisDetails;
 }
 
 }

--- a/template.php
+++ b/template.php
@@ -149,7 +149,7 @@ function UTKdrupal_preprocess_page(&$variables, $hook) {
       $variables['page']['content']['system_main']['citation.tab']['citation']['#markup']= $new_string;
       //$Revise for Abstract label display
       $thisDetails2 = str_replace('<h2>','<div class="citation_abstract_container"><h5>',$thisDetails);
-      $thisDetails3 = str_replace('<p property="description">','<p property="description" class="citation_abstract">',$thisDetails2);
+      $thisDetails3 = str_replace('<p property="description"><p>','<p property="description"><p class="citation_abstract">',$thisDetails2);
       $thisDetails4 = str_replace('</h2>','</h5></div>',$thisDetails3);
       $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']=$thisDetails4;
 }


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.lib.utk.edu/browse/TRAC-1120](https://jira.lib.utk.edu/browse/TRAC-1120)

# What does this Pull Request do?

Google Scholar Inclusion requires that font size should be as follows.
Title - Largest
Author - Second Largest
Other Headers (Downloads, Abstract, etc) - Third Largest.
The current font size for Abstract is larger than that of Author and must be revised.

In this repository, two files are changed.

    UTKdrupal/template.php
    UTKdrupal/css/style.css

#Technical details:
The HTML markup for the Details portion of the Item level page is at:

$variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']
This is a single string of HTML markup, thousands of characters.

Before changes, the beginning of the markup string looks like this:

&lt;!-- THEME DEBUG --> &lt;!-- CALL: theme('islandora_solr_metadata_description') --> &lt;!-- BEGIN OUTPUT from 'sites/all/modules/islandora_solr_metadata/theme/islandora-solr-metadata-description.tpl.php' --> <div class="islandora-solr-metadata-sidebar"> &lt;h2>Abstract &lt;/h2> &lt;p property="description">&lt;p>....text of abstract....&lt;/p>

The &lt;h2> tags must be changed to &lt;h5> tags.

The value of Abstract is wrapped in &lt;p>...&lt;/p> tags, to the citation_abstract class must be added to the wrapper.

After changes, the markup should look like this:

&lt;!-- THEME DEBUG --> &lt;!-- CALL: theme('islandora_solr_metadata_description') --> &lt;!-- BEGIN OUTPUT from 'sites/all/modules/islandora_solr_metadata/theme/islandora-solr-metadata-description.tpl.php' --> <div class="islandora-solr-metadata-sidebar"> &lt;h5>Abstract &lt;/h5> &lt;p property="description">&lt;p class"citation_abstract">....text of abstract....&lt;/p>


I applied the php str_replace function to take care of this.

Then reset the value of  
$variables['page']['content']['system_main']['citation.tab']['metadata']['#markup'] 
to show this change.


# How should this be tested?

This code is on UTKdrupal (TRAC-1120)

In github, bring up TRACE (TRAC-1059).

        vagrant up
        after it is up
        cd $DRUPAL_HOME/sites/all/themes/UTKdrupal
        git fetch origin
        git ls-remote
        This gives a list. You are looking for:
        61ee66d967756ae2da994954e32157ae5f6c8e0e	refs/pull/12/head
        git checkout pr-12
        git checkout template.php
        drush cc all

Now you are ready to test on the vagrant trace home page in the browser.
Go to vagrant TRACE home page.
Scroll down to the search by date across all collections link.
On the iby page (Search by Date), click on 2008 because the default ETDS in vagrant give results for this year.
After you get the search results for the 2008 search, click on a Title that will bring up an Item Level result page.
On the Item Level page, you should see the Abstract Header should be below the PDF link.

The Abstact header should be in a font that is smaller than Author name.

Click on inspect element for Abstract to see if it is wrapped in the following tags:

   &lt;h5>Abstract&lt;/h5>

Please check at least 3 titles for correct display on Item Level page.

Interested parties

@DonRichards @CanOfBees

