### PR TITLE
Change font size of Abstract header. Add div citation wrappers around…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -420,4 +420,8 @@ dd.collection-value.dc-description {
   text-indent: -25px; 
   padding-left: 25px;
 }
+.citation_abstract_container {
+  text-indent: -25px; 
+  padding-left: 25px;
+}
 

--- a/css/style.css
+++ b/css/style.css
@@ -433,3 +433,4 @@ font-size: 18px;
 #block-system-main a.fieldset-title {
 font-size: 18px;
 }
+

--- a/css/style.css
+++ b/css/style.css
@@ -424,4 +424,12 @@ dd.collection-value.dc-description {
   text-indent: -25px; 
   padding-left: 25px;
 }
-
+h4 {
+font-size: 25px;
+}
+h5 {
+font-size: 18px;
+}
+#block-system-main a.fieldset-title {
+font-size: 18px;
+}

--- a/template.php
+++ b/template.php
@@ -168,13 +168,23 @@ function UTKdrupal_preprocess_page(&$variables, $hook) {
     if ( isset($variables['page']['content']['system_main']['citation.tab']['citation']['#markup'])) {
       unset($variables['page']['content']['system_main']['citation.tab']['citation']['#markup']);
       }
+      //Generate display of Author name in first line below title
       $thisDetails = $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup'];
-      $Author = extractStringValue($thisDetails,'utk_mods_etd_name_author_ms');
-      $prefix  = '<div class="csl-bib-body"><div class="citation_author_container"><div class="citation_author"><h4>';
-      $content  = $Author;
-      $suffix  = '</h4></div></div></div>';
-      $new_string = $prefix.$content.$suffix;
+      $Author      = extractStringValue($thisDetails,'utk_mods_etd_name_author_ms');
+      $prefix      = '<div class="csl-bib-body"><div class="citation_author_container"><div class="citation_author"><h4>';
+      $content     = $Author;
+      $suffix      = '</h4></div></div></div>';
+      $new_string  = $prefix.$content.$suffix;
       $variables['page']['content']['system_main']['citation.tab']['citation']['#markup']= $new_string;
+      //Change font size on Abstract Header, add citation div wrappers
+      $count1        = 1;
+      $count2        = 2;
+      $thisAbstract  = str_replace('h2>','h5>',$thisDetails,$count2);
+      $thisAbstract2 = str_replace('<h5>','<div class="citation_abstract_container"><h5>',$thisAbstract);
+      $thisAbstract3 = str_replace('<p property="description"><p>','<p property="description"><p class="citation_abstract">',$thisAbstract2);
+      $thisAbstract4 = str_replace('<!-- END','</div><!-- END',$thisAbstract3,$count1);
+      $variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']= $thisAbstract4;
+      
 }
 
 }


### PR DESCRIPTION
… Abstract header and text.

**JIRA Ticket**: https://jira.lib.utk.edu/browse/TRAC-1120](TRAC-1120)

# What does this Pull Request do?
Change font size of Abstract header. Add div citation wrappers around Abstract header and text.

A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
- branches
UTKdrupal(TRAC-1120a) was created today from UTKdrupal(horizontal).
TRACE(TRAC-1120a) was created today from TRACE(master).
- files
UTKdrupal/css/style.css (added class citation_abstract_container to the end of the file)
UTKdrupal/template.php (php parsing to revise Abstract fontsize and introduce citation_abstract wrappers)


# Technical details and possible side effects.

The code to display abstract is contained in a simple string of HTML markup in
$variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']

In template.php function UTKdrupal_preprocess_page,
a variety of php string functions were applied to change the value of the string
$variables['page']['content']['system_main']['citation.tab']['metadata']['#markup']
 - The font size of the Abstract header was changed from h2 to h5.
 - A div wrapper for class="citation_abstract_container" (and </div>) were added
 - A class="citation_abstract" was added to the paragraph tag immediately before the text value of the Abstract.

# How should this be tested?
In your own git hub repo, checkout TRACE(TRAC-1120a) 
 - Do vagrant up, then vagrant ssh.
 - &gt;&gt; cd $DRUPAL_HOME/sites/all/themes/UTKdrupal
 - Use git ls-remote to find the correct branch of UTKdrupal.
 - &gt;&gt;  git ls-remote
This gives a list including reference to pull/14/head
4cbb39816ac6a369de8af9a06b3fcd91f27aecd2	refs/pull/14/head

 - Name this branch
 - &gt;&gt; git fetch origin pull/14/head:pr-14
 - Checkout the correct branch of UTKdrupal using the new ref name.
 - &gt;&gt; git checkout pr-14
Then get the files of interest and clear the cache.
 - &gt;&gt; git checkout template.php
 - &gt;&gt; git checkout css/style.css
 - &gt;&gt; drush cc all

# At this point you are ready to look at http://localhost:8000
- Bring up the vagrant home page.
- Do any search that will bring up an ETD.
 - Open the Object Level Page
 -  You should see
 - - Title......................................largest font size
 - -  Author's name.....................second largest font size
 - - Downloads............................third largest font size
 - - PDF (link)..............................third largest font size
 - - views.....................................small text size font
 - - downloads.............................small text size font
 - - Abstract (header)..................third largest font size
 - - The full text of the abstract....small text size font

This is 8 items to inspect.
If anything is missing or the wrong relative text size, please fail the PR.

Please check 3 different ETDs.


# Interested parties
@CanOfBees @DonRichards 
Tag (@ mention) interested parties.