### PR TITLE
Address TRAC-971

### DIFF
--- a/templates/islandora-basic-collection-grid.tpl.php
+++ b/templates/islandora-basic-collection-grid.tpl.php
@@ -20,7 +20,7 @@
             <!--  Title -->
             <dd class="collection-value <?php print isset($associated_object['dc_array']['dc:title']['class']) ? $associated_object['dc_array']['dc:title']['class'] : ''; ?> <?php print $row_field == 0 ? ' first' : ''; ?>">
               <?php if (isset($associated_object['thumb_link'])): ?>
-                <strong><?php print filter_xss($associated_object['title_link']); ?></strong>
+                <strong><?php print check_markup($associated_object['title_link'], 'filtered_html'); ?></strong>
               <?php endif; ?>
             </dd>
 

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -113,7 +113,7 @@ if ($title == 'Access denied') {
       <!-- Begin Breadcrumb Region -->
         <?php if (!drupal_is_front_page()) : ?>
         <div class="breadcrumb">
-            <?php print strip_tags($breadcrumb, '<a><h2>') . ' » ' . $title;?>
+            <?php print strip_tags($breadcrumb, '<a><h2>') . ' » ' . html_entity_decode($title);?>
         </div>
         <?php endif; ?>
       <!-- End Breadcrumb Region -->
@@ -152,7 +152,7 @@ if ($title == 'Access denied') {
         <?php if ($title) : ?>
         <?php print render($title_prefix); ?>
         <h1 class="title" id="page-title">
-            <?php print $title; ?>
+            <?php print html_entity_decode($title); ?>
         </h1>
         <?php print render($title_suffix); ?>
         <?php endif; ?>


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-971](https://jira.lib.utk.edu/browse/TRAC-971)

# What does this Pull Request do?
This PR **partially** addresses some of the concerns in TRAC-971: rendered inline HTML in Solr search results, Browse results (partial), and at the Item level.

# What's new?
1) changes to Configuration > Content Authoring > Text Formats > {Filtered HTML|Islandora Solr Metadata Filtered HTML} -- these changes need to be applied manually.
2) modifications to the files in this PR, wherein certain values are wrapped in functions that allow for properly filtered inline HTML.

# How should this be tested?
1) vagrant destroy
2) vagrant up
3) vagrant ssh and switch to this feature branch in UTKdrupal
4) log in as admin and update the following:
* Configuration > Content Authoring > Text Formats > Filtered HTML > configure 
  * 'Limit allowed HTML tags': add `<i> <sup> <sub>` to the list
* Configuration > Content Authoring > Text Formats > Islandora Solr Metadata Filtered HTML > configure  
  * Enable the following 'Roles': anonymous user, authenticated user, administrator
  * 'Limit allowed HTML tags': add `<i> <sup> <sub>` to the list
5) save the configuration vigorously. Between each change, even.
6) submit an ETD as userA or userB.
7) minimally, use the following for a title: `Buyer and <i>grower</i> perceptions of liner quality and associated production costs of nursery liner stock`. Feel free to add some valid Unicode characters to the title; e.g. `∛` or `∅` or `∰`. Note: prepare for bad surprises if you copy/paste from Word. 
8) minimally, use the following for an abstract: `Liner production is a <i>key</i> segment in the nursery industry. Due to a lack of specific of quality standards by governing industry organizations as well as a lack of general consensus among growers of perceived liner quality a conjoint analysis study was developed to determine buyer and grower preferences for nursery liner product features during point-of-purchase decisions. The study used a visual survey using six variables (first order lateral roots (F<sup>OLR</sup>) price region of production and height canopy density and caliper uniformity) with varying levels yielding a 3 x 3 x 3 x 2 x 2 x 2 factorial (ℤ) design.`
9) submit/accept/publish. **Note:** inline HTML does not yet render on the accept/publish pages.
10) verify that your inline HTML (and Unicode) renders correctly in
  * search
  * browse (as noted, the description will not render inline HTML correctly at this point).
  * item-level display; i.e. in-body `$title`, breadcrumbs, abstract, and the same values in the Details.

If there are problems, please report back in a comment.

# Interested parties
@utkdigitalinitiatives/digital-initiatives-developers 